### PR TITLE
Setting to allow selective disabling

### DIFF
--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -1,8 +1,14 @@
 import sublime
 import sublime_plugin
 
-class SideBarListener(sublime_plugin.EventListener):
-    
-    def on_activated(self, view):
-        view.window().run_command('reveal_in_side_bar')
 
+def get_settings_value(key):
+    settings = sublime.load_settings(__name__ + '.sublime-settings')
+    return settings.get(key)
+
+
+class SideBarListener(sublime_plugin.EventListener):
+
+    def on_activated(self, view):
+        if get_settings_value('reveal-on-activate'):
+            view.window().run_command('reveal_in_side_bar')

--- a/SyncedSideBar.sublime-settings
+++ b/SyncedSideBar.sublime-settings
@@ -1,0 +1,4 @@
+{
+	// Plugin active state. Allows projects to override this setting if it's annoying without disabling the plugin entirely.
+	"reveal-on-activate": true
+}


### PR DESCRIPTION
I just finished writing a plugin with the code from that forum post when I found your plugin in the package control list :)

I added a setting to mine that allows the plugin to be disabled without removing it completely (might come in handy in project settings, for example). Rather than have my own plugin, thought my changes might be useful to include in yours.
