### PR TITLE
Fix for console error

### DIFF
--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -10,5 +10,6 @@ def get_settings_value(key):
 class SideBarListener(sublime_plugin.EventListener):
 
     def on_activated(self, view):
-        if get_settings_value('reveal-on-activate'):
-            view.window().run_command('reveal_in_side_bar')
+        active = view.window()
+        if active and get_settings_value('reveal-on-activate'):
+            active.run_command('reveal_in_side_bar')


### PR DESCRIPTION
I just noticed a stack of errors in my console from the plugin. Turns out command palette activation triggers the event listener, but it doesn't have a window :)
