### PR TITLE
Settings regression fix

### DIFF
--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -1,15 +1,9 @@
-import sublime
 import sublime_plugin
-
-
-def get_settings_value(key):
-    settings = sublime.load_settings(__name__ + '.sublime-settings')
-    return settings.get(key)
 
 
 class SideBarListener(sublime_plugin.EventListener):
 
     def on_activated(self, view):
         active = view.window()
-        if active and get_settings_value('reveal-on-activate'):
+        if active and view.settings().get('reveal-on-activate'):
             active.run_command('reveal_in_side_bar')


### PR DESCRIPTION
It looks like sublime has changed the way settings inheritance works; the code I added for #2 was no longer working.
