### PR TITLE
fixed: https://github.com/TheSpyder/SyncedSideBar/issues/53

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -13,20 +13,11 @@
                 [
                     {
                         "caption": "SyncedSideBar",
-                        "children":
-                        [
-                            {
-                                "command": "open_file", 
-                                "args": {"file": "${packages}/SyncedSideBar/SyncedSideBar.sublime-settings"},
-                                "caption": "Settings – Default"
-                            },
-                            {
-                                "command": "open_file", 
-                                "args": {"file": "${packages}/User/SyncedSideBar.sublime-settings"},
-                                "caption": "Settings – User"
-                            },
-                            { "caption": "-" }
-                        ]
+                        "command": "edit_settings",
+                        "args": {
+                            "base_file": "${packages}/SyncedSideBar/SyncedSideBar.sublime-settings",
+                            "default": "${packages}/User/SyncedSideBar.sublime-settings",
+                        }
                     }
                 ]
             }

--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -127,7 +127,7 @@ class SideBarListener(sublime_plugin.EventListener):
         # don't even consider updating state if we don't have a window.
         # reveal in side bar is a window command only.
         # 'goto anything' activates views but doesn't set a window until the file is selected.
-        if not view.window():
+        if view.settings().get("is_widget", False):
             return
 
         global lastView

--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -124,9 +124,6 @@ def show_view(view):
 
 class SideBarListener(sublime_plugin.EventListener):
     def on_activated(self, view):
-
-        self.packageSettings = sublime.load_settings('SyncedSideBar.sublime-settings')
-
         # don't even consider updating state if we don't have a window.
         # reveal in side bar is a window command only.
         # 'goto anything' activates views but doesn't set a window until the file is selected.
@@ -150,16 +147,10 @@ class SideBarListener(sublime_plugin.EventListener):
             global sidebarVisible
             sidebarVisible = not sidebarVisible
 
-        # This is needed for the `on_post_window_command` to work
-        if command == 'reveal_in_side_bar':
-            self.last_view = window.active_view()
-
-
     # Back to the file window after `reveal_in_side_bar` command
     def on_post_window_command(self, window, command, args):
         if command == 'reveal_in_side_bar':
-            if self.packageSettings.get('focus-on-view'):
-                window.focus_view(self.last_view)
+            window.focus_view(lastView)
 
 
 class SideBarUpdateSync(sublime_plugin.ApplicationCommand):

--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -116,7 +116,6 @@ def show_view(view):
 
         if shouldReveal and reveal != False:
             win.run_command('reveal_in_side_bar')
-            win.run_command('focus_group', "args": { "group": 1 })
 
     # When using quick switch project, the view activates before the sidebar is ready.
     # This tiny delay is imperceptible but works around the issue.

--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -124,6 +124,9 @@ def show_view(view):
 
 class SideBarListener(sublime_plugin.EventListener):
     def on_activated(self, view):
+
+        self.packageSettings = sublime.load_settings('SyncedSideBar.sublime-settings')
+
         # don't even consider updating state if we don't have a window.
         # reveal in side bar is a window command only.
         # 'goto anything' activates views but doesn't set a window until the file is selected.
@@ -142,10 +145,21 @@ class SideBarListener(sublime_plugin.EventListener):
 
     # Sublime text v3 window command listener, safe to include unconditionally as it's simply ignored by v2.
     # Eventually, v3 support below 3098 will be dropped and this can be deleted.
-    def on_window_command(self, window, command_name, args):
-        if command_name == 'toggle_side_bar':
+    def on_window_command(self, window, command, args):
+        if command == 'toggle_side_bar':
             global sidebarVisible
             sidebarVisible = not sidebarVisible
+
+        # This is needed for the `on_post_window_command` to work
+        if command == 'reveal_in_side_bar':
+            self.last_view = window.active_view()
+
+
+    # Back to the file window after `reveal_in_side_bar` command
+    def on_post_window_command(self, window, command, args):
+        if command == 'reveal_in_side_bar':
+            if self.packageSettings.get('focus-on-view'):
+                window.focus_view(self.last_view)
 
 
 class SideBarUpdateSync(sublime_plugin.ApplicationCommand):

--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -116,6 +116,7 @@ def show_view(view):
 
         if shouldReveal and reveal != False:
             win.run_command('reveal_in_side_bar')
+            win.run_command('focus_group', "args": { "group": 1 })
 
     # When using quick switch project, the view activates before the sidebar is ready.
     # This tiny delay is imperceptible but works around the issue.

--- a/SyncedSideBar.sublime-settings
+++ b/SyncedSideBar.sublime-settings
@@ -13,13 +13,6 @@
 	"reveal-on-activate": true,
 
 	/*
-	 * After reveal on sidebar, focus on file window view.
-	 *
-	 * Defaults to true.
-	 */
-	"focus-on-view": true,
-
-	/*
 	 * Controls window switch behaviour.
 	 *
 	 * By default, when new windows are opened the plugin will switch to

--- a/SyncedSideBar.sublime-settings
+++ b/SyncedSideBar.sublime-settings
@@ -13,6 +13,13 @@
 	"reveal-on-activate": true,
 
 	/*
+	 * After reveal on sidebar, focus on file window view.
+	 *
+	 * Defaults to true.
+	 */
+	"focus-on-view": true,
+
+	/*
 	 * Controls window switch behaviour.
 	 *
 	 * By default, when new windows are opened the plugin will switch to


### PR DESCRIPTION
Fix input focus on Sublime Text 3/4 and added a option to focus on file window after reveal.