### PR TITLE
Avoid crash when editing Git commit message in Sublime Text < 4148

### DIFF
--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -107,6 +107,11 @@ def show_view(view):
     win = view.window()
 
     def revealLater():
+        # Some versions of Sublime Text crash when revealing files under `.git/` in the side bar:
+        # https://github.com/sublimehq/sublime_text/issues/5881
+        if int(sublime.version()) < 4148 and '/.git/' in str(win.active_view().file_name()):
+            return
+
         if (int(sublime.version()) >= 3098):
             # API provided by sublime
             shouldReveal = win.is_sidebar_visible()
@@ -115,11 +120,6 @@ def show_view(view):
             shouldReveal = sidebarVisible
 
         if shouldReveal and reveal != False:
-            # Some versions of Sublime Text crash when revealing files under `.git/` in the side bar:
-            # https://github.com/sublimehq/sublime_text/issues/5881
-            if int(sublime.version()) < 4148 and '/.git/' in str(win.active_view().file_name()):
-                return
-
             win.run_command('reveal_in_side_bar')
 
     # When using quick switch project, the view activates before the sidebar is ready.

--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -115,9 +115,9 @@ def show_view(view):
             shouldReveal = sidebarVisible
 
         if shouldReveal and reveal != False:
-            # Workaround for crash when editing Git commit message: https://github.com/TheSpyder/SyncedSideBar/issues/61
-            currentFileName = win.active_view().file_name()
-            if currentFileName is not None and '/.git/' in currentFileName:
+            # Some versions of Sublime Text crash when revealing files under `.git/` in the side bar:
+            # https://github.com/sublimehq/sublime_text/issues/5881
+            if int(sublime.version()) < 4148 and '/.git/' in str(win.active_view().file_name()):
                 return
 
             win.run_command('reveal_in_side_bar')

--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -115,6 +115,11 @@ def show_view(view):
             shouldReveal = sidebarVisible
 
         if shouldReveal and reveal != False:
+            # Workaround for crash when editing Git commit message: https://github.com/TheSpyder/SyncedSideBar/issues/61
+            currentFileName = win.active_view().file_name()
+            if currentFileName is not None and '/.git/' in currentFileName:
+                return
+
             win.run_command('reveal_in_side_bar')
 
     # When using quick switch project, the view activates before the sidebar is ready.


### PR DESCRIPTION
Fixes #61

Selecting "Reveal in Side Bar" when editing a file inside a `.git/` directory crashes some versions of Sublime Text. This was fixed in Sublime Text 4148: https://github.com/sublimehq/sublime_text/issues/5881

Since SyncedSideBar automatically calls "Reveal in Side Bar", Sublime Text will instantly crash when e.g. editing a Git commit message while running SyncedSideBar. This pull request introduces a workaround for the issue, skipping revealing Git files in the sidebar in versions of Sublime Text prior to 4148.

I'm not sure which version of Sublime Text introduced the crash, so I haven't added a lower version to the check. This means that SyncedSideBar won't reveal files under `.git/` in older versions of Sublime Text, even if there's no risk of a crash in those versions. This shouldn't be an issue for most users since Sublime Text doesn't display `.git/` directories in the side bar by default, but may cause unexpected behaviour for some users.