### PR TITLE
Ignore file patterns when provided via setting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Settings can be overridden on a per-project basis by adding them to the `setting
 
 * `reveal-on-activate` controls the automatic reveal as the active tab changes (true by default).
 * `reveal-all-tabs` controls whether or not the plugin will cycle through all tabs when a window opens (true by default).
-
+* `reveal-ignore-patterns` controls which file patterns to ignore when revealing a tab in the sidebar (none by default).
 
 Sublime versions and sidebar visibility
 ---------------------------------------

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Settings can be overridden on a per-project basis by adding them to the `setting
 
 * `reveal-on-activate` controls the automatic reveal as the active tab changes (true by default).
 * `reveal-all-tabs` controls whether or not the plugin will cycle through all tabs when a window opens (true by default).
-* `reveal-ignore-patterns` controls which file patterns to ignore when revealing a tab in the sidebar (none by default).
+* `reveal-ignore-patterns` controls [filename patterns](https://docs.python.org/3/library/fnmatch.html) to ignore when revealing a tab in the sidebar (none by default). Those patterns match against full file paths.
 
 Sublime versions and sidebar visibility
 ---------------------------------------

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Settings can be overridden on a per-project basis by adding them to the `setting
 
 * `reveal-on-activate` controls the automatic reveal as the active tab changes (true by default).
 * `reveal-all-tabs` controls whether or not the plugin will cycle through all tabs when a window opens (true by default).
-* `reveal-ignore-patterns` controls [filename patterns](https://docs.python.org/3/library/fnmatch.html) to ignore when revealing a tab in the sidebar (none by default). Those patterns match against full file paths.
+* `reveal-ignore-patterns` controls [filename patterns](https://docs.python.org/3/library/fnmatch.html) to ignore when revealing a tab in the sidebar (none by default). These patterns match against full file paths.
 
 Sublime versions and sidebar visibility
 ---------------------------------------
 
-This plugin works on both Sublime Text 2 and Sublime Text 3 beta. The new capabilities enabled by ST3 are designed to gracefully degrade to the old behaviour on ST2.
+This plugin works on Sublime Text 2 and later. New capabilities enabled by ST3 and above are designed to gracefully degrade to the old behaviour on ST2.
 
-With ST3 build `3098` or above the plugin makes use of the new sidebar visibility API to disable automatic syncing when the sidebar is hidden.
+With ST4 and ST3 build `3098` or above the plugin makes use of the sidebar visibility API to disable automatic syncing when the sidebar is hidden.
 
 With ST3 builds `3025`-`3097` the plugin _monitors_ sidebar visibility. It forces the sidebar to become visible the first time a window is opened in each Sublime session, and after that watches for the sidebar hide command to disable automatic syncing until it is shown again.
 

--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -1,8 +1,11 @@
+# pyright: reportMissingImports=false
+
 import sublime
 import sublime_plugin
 
 # ++++ old hacks ++++
-# before ST3 build 3098 we assume sidebar is visible by default on every window (there's no way to check, unfortunately)
+# before ST3 build 3098 we assume sidebar is visible by default on every window
+# (there's no way to check, unfortunately)
 DEFAULT_VISIBILITY = True
 sidebarVisible = DEFAULT_VISIBILITY
 
@@ -19,9 +22,12 @@ pluginPref = DEFAULT_VISIBILITY
 # flag for alt-tab focus check
 lastView = None
 
+PACKAGE_SETTINGS = 'SyncedSideBar.sublime-settings'
+USER_SETTINGS    = 'Preferences.sublime-settings'
+
 def plugin_loaded():
-    userSettings    = sublime.load_settings('Preferences.sublime-settings')
-    packageSettings = sublime.load_settings('SyncedSideBar.sublime-settings')
+    userSettings = sublime.load_settings(USER_SETTINGS)
+    packageSettings = sublime.load_settings(PACKAGE_SETTINGS)
 
     def read_pref_user():
         vis = userSettings.get('reveal-on-activate')
@@ -50,41 +56,42 @@ if (int(sublime.version()) < 3000):
 
 def reveal_all(view):
     visUser = view.settings().get('reveal-all-tabs')
-    #print( 'view.settings().get(reveal-all-tabs): ' + str( visUser ) )
 
     if visUser is None:
-        packageSettings = sublime.load_settings('SyncedSideBar.sublime-settings')
-        visPackage      = packageSettings.get('reveal-all-tabs')
+        packageSettings = sublime.load_settings(PACKAGE_SETTINGS)
+        visPackage = packageSettings.get('reveal-all-tabs')
         if visPackage is False:
             return
     elif visUser is False:
         return
 
-    activeWindow = view.window();
-    viewList     = activeWindow.views();
+    activeWindow = view.window()
+    viewList = activeWindow.views()
 
-    # Use set_timeout to give sublime a chance to fire normal events between tab changes
+    # Use set_timeout to give sublime a chance to fire normal events
+    # between tab changes
     def reveal():
-        if (len(viewList) > 0):
+        if viewList:
             target = viewList.pop()
             activeWindow.focus_view(target)
-            sublime.set_timeout(reveal, 25);
+            sublime.set_timeout(reveal, 25)
         else:
-            # all tabs have been activated in this window, restore focus to the tab that was first active
+            # all tabs have been activated in this window, restore focus to the
+            # tab that was first active
             activeWindow.focus_view(view)
-    sublime.set_timeout(reveal, 50);
+    sublime.set_timeout(reveal, 50)
 
 
 def manage_state(view):
     activeWindow = view.window()
 
-    if not activeWindow.id() in windows:
-        # first activation in this window, use default (unused for 3098 and above, but we need to store *something*)
+    if activeWindow.id() not in windows:
+        # first activation in this window, use default (unused for 3098
+        # and above, but we need to store *something*)
         windows[activeWindow.id()] = DEFAULT_VISIBILITY
 
         # fire 'reveal all' in the background
         reveal_all(view)
-
 
     # ++++ old hacks ++++
     if (int(sublime.version()) < 3098):
@@ -104,36 +111,38 @@ def manage_state(view):
 def show_view(view):
     userPref = view.settings().get('reveal-on-activate')
     reveal = userPref if userPref is not None else pluginPref
-    win = view.window()
+    window = view.window()
 
     def revealLater():
-        # Some versions of Sublime Text crash when revealing files under `.git/` in the side bar:
+        # Some versions of Sublime Text crash when revealing files
+        # under `.git/` in the side bar:
         # https://github.com/sublimehq/sublime_text/issues/5881
         if int(sublime.version()) < 4148:
-            active_view = win.active_view()
-            if active_view and '/.git/' in str(active_view.file_name()):
+            activeView = window.active_view()
+            if activeView and '/.git/' in str(activeView.file_name()):
                 return
 
         if (int(sublime.version()) >= 3098):
             # API provided by sublime
-            shouldReveal = win.is_sidebar_visible()
+            shouldReveal = window.is_sidebar_visible()
         else:
             # backwards compatibility
             shouldReveal = sidebarVisible
 
-        if shouldReveal and reveal != False:
-            win.run_command('reveal_in_side_bar')
+        if shouldReveal and reveal is not False:
+            window.run_command('reveal_in_side_bar')
 
-    # When using quick switch project, the view activates before the sidebar is ready.
-    # This tiny delay is imperceptible but works around the issue.
-    sublime.set_timeout(revealLater, 100);
+    # When using quick switch project, the view activates before the sidebar
+    # is ready. This tiny delay is imperceptible but works around the issue.
+    sublime.set_timeout(revealLater, 100)
 
 
 class SideBarListener(sublime_plugin.EventListener):
     def on_activated(self, view):
         # don't even consider updating state if we don't have a window.
         # reveal in side bar is a window command only.
-        # 'goto anything' activates views but doesn't set a window until the file is selected.
+        # 'goto anything' activates views but doesn't set a window
+        # until the file is selected.
         if view.settings().get("is_widget", False):
             return
 
@@ -146,33 +155,31 @@ class SideBarListener(sublime_plugin.EventListener):
         manage_state(view)
         show_view(view)
 
-
-    # Sublime text v3 window command listener, safe to include unconditionally as it's simply ignored by v2.
-    # Eventually, v3 support below 3098 will be dropped and this can be deleted.
-    def on_window_command(self, window, command, args):
-        if command == 'toggle_side_bar':
+    # Sublime text v3 window command listener, safe to include unconditionally
+    # as it's simply ignored by v2. Eventually, v3 support
+    # below 3098 will be dropped and this can be deleted.
+    def on_window_command(self, window, command, _):
+        if command == 'toggle_side_bar' and window.is_valid():
             global sidebarVisible
             sidebarVisible = not sidebarVisible
 
-    def on_post_window_command(self, window, command, args):
+    def on_post_window_command(self, window, command, _):
         # v4 leaves focus on the sidebar after a `reveal_in_side_bar` command
         # So we need to manually force focus back to the file window
         if (int(sublime.version()) > 4000 and int(sublime.version()) < 4099):
-            if command == 'reveal_in_side_bar':
+            if command == 'reveal_in_side_bar' and window.is_valid():
                 window.focus_view(lastView)
 
 
 class SideBarUpdateSync(sublime_plugin.ApplicationCommand):
     # Update user preferences with the new value
     def run(self, enable):
-        userSettings = sublime.load_settings('Preferences.sublime-settings')
-        vis          = userSettings.get('reveal-on-activate')
+        userSettings = sublime.load_settings(USER_SETTINGS)
+        vis = userSettings.get('reveal-on-activate')
         if vis is not None:
             userSettings.set('reveal-on-activate', enable)
-            sublime.save_settings('Preferences.sublime-settings')
+            sublime.save_settings(USER_SETTINGS)
         else:
-            packageSettings = sublime.load_settings('SyncedSideBar.sublime-settings')
+            packageSettings = sublime.load_settings(PACKAGE_SETTINGS)
             packageSettings.set('reveal-on-activate', enable)
-            sublime.save_settings('SyncedSideBar.sublime-settings')
-
-
+            sublime.save_settings(PACKAGE_SETTINGS)

--- a/SyncedSideBar.py
+++ b/SyncedSideBar.py
@@ -41,7 +41,7 @@ def plugin_loaded():
             pluginPref = vis
 
         ignores = userSettings.get('reveal-ignore-patterns')
-        if ignores:
+        if ignores is not None:
             global pluginPatterns
             pluginPatterns = ignores
 
@@ -52,7 +52,7 @@ def plugin_loaded():
             pluginPref = vis
 
         ignores = packageSettings.get('reveal-ignore-patterns')
-        if ignores:
+        if ignores is not None:
             global pluginPatterns
             pluginPatterns = ignores
 
@@ -128,7 +128,7 @@ def show_view(view):
     reveal = userPref if userPref is not None else pluginPref
 
     userPatterns = view.settings().get('reveal-ignore-patterns')
-    patterns = userPatterns if userPatterns else pluginPatterns
+    patterns = userPatterns if userPatterns is not None else pluginPatterns
 
     activeWindow = view.window()
 

--- a/SyncedSideBar.sublime-settings
+++ b/SyncedSideBar.sublime-settings
@@ -18,5 +18,12 @@
 	 * By default, when new windows are opened the plugin will switch to
 	 * all available views so the sidebar is expanded properly.
 	 */
-	"reveal-all-tabs": true
+	"reveal-all-tabs": true,
+
+	/*
+	 * List of file patterns to ignore when revealing a tab in the sidebar.
+	 *
+	 * By default, no file patterns are ignored.
+	 */
+	"reveal-ignore-patterns": [],
 }

--- a/SyncedSideBar.sublime-settings
+++ b/SyncedSideBar.sublime-settings
@@ -21,7 +21,9 @@
 	"reveal-all-tabs": true,
 
 	/*
-	 * List of file patterns to ignore when revealing a tab in the sidebar.
+	 * List of filename patterns to ignore when revealing a tab in the sidebar
+	 * (see https://docs.python.org/3/library/fnmatch.html for more details).
+	 * Those patterns match against full file paths.
 	 *
 	 * By default, no file patterns are ignored.
 	 */

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -1,0 +1,53 @@
+{
+    "contributions": {
+        "settings": [
+            {
+                "schema": {
+                    "$id": "sublime://settings/SyncedSideBar",
+                    "properties": {
+                        "reveal-on-activate": {
+                            "type": "boolean",
+                            "markdownDescription": "Plugin active state.\n\nDefaults to true.",
+                            "default": "true"
+                        },
+                        "reveal-all-tabs": {
+                            "type": "boolean",
+                            "markdownDescription": "Controls window switch behaviour.\n\nBy default, when new windows are opened the plugin will switch to all available views so the sidebar is expanded properly.",
+                            "default": "true"
+                        },
+                        "reveal-ignore-patterns": {
+                            "type": "array",
+                            "markdownDescription": "List of [filename patterns](https://docs.python.org/3/library/fnmatch.html) to ignore when revealing a tab in the sidebar. Those patterns match against full file paths.\n\nBy default, no file patterns are ignored.",
+                            "default": []
+                        }
+                    }
+                },
+            },
+            {
+                "file_patterns": ["/SyncedSideBar.sublime-settings"],
+                "schema": {
+                    "$ref": "sublime://settings/SyncedSideBar",
+                    "additionalProperties": false
+                }
+            },
+            {
+                "file_patterns": ["/Preferences.sublime-settings"],
+                "schema": {
+                    "$ref": "sublime://settings/SyncedSideBar",
+                    "additionalProperties": true
+                }
+            },
+            {
+                "file_patterns": ["/*.sublime-project"],
+                "schema": {
+                    "properties": {
+                        "settings": {
+                            "$ref": "sublime://settings/SyncedSideBar",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This PR adds an option to ignore file patterns when provided via the `reveal-ignore-patterns` setting requested in #50, which I'd imagine shows its usefulness when working in an environment with in-project dependencies (e.g. Node.js with `node_modules` or Python with `venv`). The list is by default empty.

ebebc73 is the commit that adds the feature; 11fb69f fixes most of the obnoxious linter/formatter errors (semicolons, extra newlines, long LoC and such).